### PR TITLE
Cr checklist action parameters example

### DIFF
--- a/docs/yii/code-review-checklist.md
+++ b/docs/yii/code-review-checklist.md
@@ -159,7 +159,7 @@ public function actionIndex()
 Good:
 ```php
 //SomeController.php
-public function actionIndex(int $foo, int $bar = 10)
+public function actionIndex(int $foo,int $bar = 10)
 {
     $foo += $bar;
 }

--- a/docs/yii/code-review-checklist.md
+++ b/docs/yii/code-review-checklist.md
@@ -144,13 +144,13 @@ Bad:
 //SomeController.php
 public function actionIndex()
 {
-    $foo = Yii::$app->request->get('foo');
+    $foo = (int)Yii::$app->request->get('foo');
 
     if($foo === null) {
         throw new yii\web\BadRequestHttpException('Parameter $foo is required.');
     }
     
-    $bar = Yii::$app->request->get('bar', 10);
+    $bar = (int)Yii::$app->request->get('bar', 10);
     
     $foo += $bar;
 }
@@ -159,7 +159,7 @@ public function actionIndex()
 Good:
 ```php
 //SomeController.php
-public function actionIndex($foo, $bar = 10)
+public function actionIndex(int $foo, int $bar = 10)
 {
     $foo += $bar;
 }

--- a/docs/yii/code-review-checklist.md
+++ b/docs/yii/code-review-checklist.md
@@ -144,7 +144,7 @@ Bad:
 //SomeController.php
 public function actionIndex()
 {
-    $foo = (int)Yii::$app->request->get('foo');
+    $foo = Yii::$app->request->get('foo');
 
     if($foo === null) {
         throw new yii\web\BadRequestHttpException('Parameter $foo is required.');
@@ -152,7 +152,7 @@ public function actionIndex()
     
     $bar = (int)Yii::$app->request->get('bar', 10);
     
-    $foo += $bar;
+    $foo = (int)$foo + $bar;
 }
 ```
 


### PR DESCRIPTION
Zaboravila sam da su to stringovi ustvari pa treba još castat u int, a zapravo se i to može riješiti type hintanjem, onda yii proslijedi pravi int. Ista stvar vrijedi i za array. 

```php
public function actionIndex(array $foo){}
```
kad ovo dobije ..?foo=bar, varijabla $foo u actionu će biti

```php
['bar']
```
